### PR TITLE
tiny fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A sample repo for setting up a server side react rendering with l10n.
 
 ```
-> cp sample.env
+> cp sample.env .env
 > npm install
 > npm start
 ```


### PR DESCRIPTION
although that said, I'm sure there's a way to make that part of `npm install` with a conditional check so that it only copies the file if there is no `.env` yet (using a node cli util, not a unix `cp`, since that's not cross-platform)
